### PR TITLE
Bump poi from 3.9 to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>3.9</version>
+            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.itextpdf</groupId>


### PR DESCRIPTION
Bumps poi from 3.9 to 4.1.1.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>